### PR TITLE
Get log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ The metrics (prefix `M`) sources can be enabled and disabled based on source nam
 First, if present, the all command is executed, then specific sources:
 - `M*:disable,memory:enable,net-solo5:enable` disables all metrics sources, and then enables *memory* and *net-solo5*
 - `Mnet-solo5:disable` disables the *net-solo5* metrics source.
+
+The log levels for the log sources can be inspected:
+- `l` reports the log level for all log sources
+- `lmonitoring-experiments,dns` reports the log level for monitoring-experiments and dns respectively

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ First, if present, the all command is executed, then specific sources:
 - `Mnet-solo5:disable` disables the *net-solo5* metrics source.
 
 The log levels for the log sources can be inspected:
-- `l` reports the log level for all log sources
+- `l` reports the default log level and the log level for all log sources
+- `l*` reports the default log level only
 - `lmonitoring-experiments,dns` reports the log level for monitoring-experiments and dns respectively.
 
 Likewise, metrics status can be similarly inspected:

--- a/README.md
+++ b/README.md
@@ -23,4 +23,8 @@ First, if present, the all command is executed, then specific sources:
 
 The log levels for the log sources can be inspected:
 - `l` reports the log level for all log sources
-- `lmonitoring-experiments,dns` reports the log level for monitoring-experiments and dns respectively
+- `lmonitoring-experiments,dns` reports the log level for monitoring-experiments and dns respectively.
+
+Likewise, metrics status can be similarly inspected:
+- `m` reports the metrics status for all metrics sources
+- `mmemory,net-solo5` reports the metrics status for memory and net-solo5 respectively.

--- a/src/monitoring_experiments.ml
+++ b/src/monitoring_experiments.ml
@@ -48,15 +48,16 @@ let get_log_levels s =
   let qs = (String.split_on_char ',' s) in
   let srcs = Logs.Src.list () in
   let src_names = List.map Logs.Src.name srcs in
-  let* () =
-    match List.find_opt (fun src -> not (List.mem src src_names)) qs with
-    | Some bad_src -> Error ("unknown source: " ^ bad_src)
-    | None -> Ok ()
-  in
-  let srcs =
+  let* srcs =
     match qs with
-    | [""] -> srcs
-    | qs -> List.filter (fun src -> List.mem (Logs.Src.name src) qs) srcs
+    | [""] -> Ok srcs
+    | qs -> 
+      let* () =
+        match List.find_opt (fun src -> not (List.mem src src_names)) qs with
+        | Some bad_src -> Error ("unknown source: " ^ bad_src)
+        | None -> Ok ()
+      in
+      Ok (List.filter (fun src -> List.mem (Logs.Src.name src) qs) srcs)
   in
   let levels =
     List.map (fun src -> Logs.Src.name src ^ ":" ^ Logs.level_to_string (Logs.Src.level src)) srcs


### PR DESCRIPTION
I imagine it can get difficult to remember what log sources are set to what log levels after a while. To make it easier for the operator a new command is added to list all log levels using the command `l` (lower case L). It can take an optional comma-separated list of source names to narrow down what is reported. Otherwise, all sources are reported.

A similar command can be implemented for metrics.